### PR TITLE
Fixed Competitor limits

### DIFF
--- a/tables/competitions_extra.sql
+++ b/tables/competitions_extra.sql
@@ -102,7 +102,7 @@ SELECT
 	a.announced_at announcedAt,
 	a.results_posted_at resultsPostedAt,
 	IF(DATEDIFF(a.start_date,CURDATE()) >0, 1, 0) upcoming,
-	a.competitor_limit competitorLimit,
+	IF(a.competitor_limit_enabled IS NULL, NULL, a.competitor_limit) competitorLimit,
 	g.competitors,
 	IFNULL(h.firstTimers,IF(DATEDIFF(a.start_date,CURDATE()) < 0,0,NULL)) firstTimers,
 	i.events,


### PR DESCRIPTION
Competitor limit should be NULL if competitor_limit_enabled is NULL (this isn't the case with 18 competitions)