### PR TITLE
Removed 4/5BLD from eventsAverage

### DIFF
--- a/tables/persons_extra.sql
+++ b/tables/persons_extra.sql
@@ -110,7 +110,7 @@ CREATE TABLE persons_extra
         COUNT(DISTINCT (CASE WHEN personCountryId != compCountryId AND compCountryId NOT LIKE 'X_' THEN competitionId END)) `foreignCountryComps`, 
         COUNT(DISTINCT (CASE WHEN eventId NOT IN ('333mbo','magic','mmagic') THEN eventId END)) `eventsAttempted`, 
         COUNT(DISTINCT (CASE WHEN best > 0 AND eventId NOT IN ('333mbo','magic','mmagic') THEN eventId END)) `eventsSucceeded`,
-        COUNT(DISTINCT (CASE WHEN average > 0 AND eventId NOT IN ('333mbo','magic','mmagic') THEN eventId END)) `eventsAverage`,
+        COUNT(DISTINCT (CASE WHEN average > 0 AND eventId NOT IN ('444bf','555bf','333mbo','magic','mmagic') THEN eventId END)) `eventsAverage`,
         COUNT(DISTINCT (CASE WHEN average > 0 AND eventId NOT IN ('333mbo','magic','mmagic','333bf','444bf','555bf','333mbf','333fm') THEN eventId END)) `speedsolvingEventsAverage`,
         COUNT(DISTINCT (CASE WHEN average > 0 AND eventId IN ('333bf','444bf','555bf','333fm') THEN eventId END)) `bldfmcEventsAverage`,
         COUNT(CASE WHEN roundTypeId IN ('c','f') THEN 1 END) `finals`,


### PR DESCRIPTION
Kinda fucked up the membership stuff since it said people like Callum are Bronze members, since he's got 16 events averaged when you include 4BLD